### PR TITLE
Add tmp as exposed volume; Closes #11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,2 @@
 FROM google/dart-runtime
+VOLUME /tmp


### PR DESCRIPTION
In order to pass crendetialing into the container it must expose the volume.